### PR TITLE
fix: flag timed-out modules even when they produced partial results

### DIFF
--- a/src/tests-reporting/functions/summarize-junit-report.test.ts
+++ b/src/tests-reporting/functions/summarize-junit-report.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { summarizeJunitReport, TestReport } from "./summarize-junit-report";
+import { summarizeJunitReport, TestMetadata, TestReport } from "./summarize-junit-report";
 
 describe("summarize-junit-report test", () => {
     const testReportsWithGreenTests: TestReport[] = [
@@ -345,5 +345,79 @@ describe("summarize-junit-report test", () => {
 
     expect(res.hasErrors).equal(false);
     expect(res.markdownContent).contain("success ✅");
+  });
+
+  it("should flag a FAILED module that timed out AFTER producing partial XML (green rows must not hide the failure)", async () => {
+    // The regression this guards: a module's test task times out after some test classes
+    // have already flushed their JUnit XML. Those rows are green and the module appears in
+    // the report, so the old detection (which only looked at modules with NO xml) ignored
+    // the FAILED state and the report said success. It must now be flagged as a failure.
+    const metadata: TestMetadata = {
+      timeoutMinutes: 30,
+      modules: {
+        "java-module-1": { state: "FAILED", hasTestSources: true, hasXmlResults: true },
+      },
+    };
+
+    const res = summarizeJunitReport(testReportsWithGreenTests, { onlyErrors: true, metadata });
+
+    expect(res.hasErrors).equal(true);
+    expect(res.markdownContent).contain("java-module-1");
+    expect(res.markdownContent).contain("partial");
+    expect(res.markdownContent).contain("30-minute");
+  });
+
+  it("should flag a FAILED module that produced no XML results at all (absent from the report)", async () => {
+    const metadata: TestMetadata = {
+      timeoutMinutes: 30,
+      modules: {
+        "java-module-1": { state: "SUCCESS", hasTestSources: true, hasXmlResults: true },
+        "webserver-ee": { state: "FAILED", hasTestSources: true, hasXmlResults: false },
+      },
+    };
+
+    const res = summarizeJunitReport(testReportsWithGreenTests, { onlyErrors: true, metadata });
+
+    expect(res.hasErrors).equal(true);
+    expect(res.markdownContent).contain("webserver-ee");
+    expect(res.markdownContent).contain("not included");
+    expect(res.markdownContent).contain("30-minute");
+  });
+
+  it("should flag a NOT_RUN module with test sources but no results", async () => {
+    const metadata: TestMetadata = {
+      timeoutMinutes: 30,
+      modules: {
+        "java-module-1": { state: "SUCCESS", hasTestSources: true, hasXmlResults: true },
+        "core-ee": { state: "NOT_RUN", hasTestSources: true, hasXmlResults: false },
+      },
+    };
+
+    const res = summarizeJunitReport(testReportsWithGreenTests, { onlyErrors: true, metadata });
+
+    expect(res.hasErrors).equal(true);
+    expect(res.markdownContent).contain("core-ee");
+    expect(res.markdownContent).contain("No test results were produced");
+  });
+
+  it("should NOT flag healthy modules when metadata reports them SUCCESS with results", async () => {
+    const metadata: TestMetadata = {
+      timeoutMinutes: 30,
+      modules: {
+        "java-module-1": { state: "SUCCESS", hasTestSources: true, hasXmlResults: true },
+      },
+    };
+
+    const res = summarizeJunitReport(testReportsWithGreenTests, { onlyErrors: true, metadata });
+
+    expect(res.hasErrors).equal(false);
+    expect(res.markdownContent).not.contain("investigation");
+  });
+
+  it("should not flag anything when no metadata is provided (backwards compatible)", async () => {
+    const res = summarizeJunitReport(testReportsWithGreenTests, { onlyErrors: true });
+
+    expect(res.hasErrors).equal(false);
+    expect(res.markdownContent).not.contain("investigation");
   });
 });

--- a/src/tests-reporting/functions/summarize-junit-report.ts
+++ b/src/tests-reporting/functions/summarize-junit-report.ts
@@ -37,18 +37,23 @@ export function summarizeJunitReport(
 
   let markdownContent = "";
 
-  // Detect missing modules (have test sources but no XML results)
-  const missingModules = detectMissingModules(metadata, testReports);
-  if (missingModules.length > 0) {
+  // Detect modules whose test task did not complete cleanly (no results, or FAILED with
+  // only partial results — e.g. a timeout). These must surface even when every XML row is
+  // green, otherwise a timed-out module is silently reported as success.
+  const problematicModules = detectProblematicModules(metadata, testReports);
+  if (problematicModules.length > 0) {
     hasErrors = true;
     const timeoutMin = metadata?.timeoutMinutes ?? 30;
-    const moduleLines = missingModules.map((m) => {
+    const moduleLines = problematicModules.map((m) => {
+      if (m.hasPartialResults) {
+        return `- \`${m.name}\` — test task **FAILED** (likely exceeded the ${timeoutMin}-minute timeout). The results shown below for this module are **partial** and may not reflect every test.`;
+      }
       if (m.state === "FAILED") {
         return `- \`${m.name}\` — test task **FAILED** (likely exceeded the ${timeoutMin}-minute timeout). Results for this module are **not included** in the report below.`;
       }
       return `- \`${m.name}\` — test task state: ${m.state}. No test results were produced.`;
     });
-    markdownContent += `\n> ⚠️ **${missingModules.length} module(s) with tests produced no results — investigation required:**\n>\n${moduleLines.map(l => `> ${l}`).join("\n")}\n\n`;
+    markdownContent += `\n> ⚠️ **${problematicModules.length} module(s) need investigation (test task failed or produced no results):**\n>\n${moduleLines.map(l => `> ${l}`).join("\n")}\n\n`;
   }
 
   if (!testReports || testReports.length === 0) {
@@ -143,23 +148,41 @@ export function summarizeJunitReport(
   return { hasErrors, markdownContent };
 }
 
-function detectMissingModules(
+interface ProblematicModule {
+  name: string;
+  state: string;
+  // true when the module DID produce (partial) XML results that are included in the
+  // report below, despite its test task having FAILED — e.g. a timeout that killed the
+  // JVM mid-suite after some test classes had already flushed their XML. The results are
+  // present but incomplete, so we still flag the module instead of trusting the green rows.
+  hasPartialResults: boolean;
+}
+
+// Detect modules whose test task did not complete cleanly, using the per-module states
+// from build/test-metadata.json. Two distinct failure shapes are surfaced:
+//  1. No results at all — module has test sources but produced no XML (state FAILED/NOT_RUN).
+//     The whole module is absent from the report below.
+//  2. Partial results — module is in the report (has XML) but its test task FAILED. This is
+//     the common timeout-after-partial-flush case: the green rows below under-report reality.
+function detectProblematicModules(
     metadata: TestMetadata | undefined,
     testReports: TestReport[],
-): Array<{ name: string; state: string }> {
+): ProblematicModule[] {
   if (!metadata?.modules) return [];
   const reportedProjects = new Set(
       mergeSameProjectReports(testReports).map((r) => r.projectName),
   );
-  const missing: Array<{ name: string; state: string }> = [];
+  const problematic: ProblematicModule[] = [];
   for (const [name, mod] of Object.entries(metadata.modules)) {
-    if (mod.hasTestSources && !mod.hasXmlResults && !reportedProjects.has(name)) {
-      if (mod.state === "FAILED" || mod.state === "NOT_RUN") {
-        missing.push({ name, state: mod.state });
-      }
+    if (!mod.hasTestSources) continue;
+    const isAbsent = !mod.hasXmlResults && !reportedProjects.has(name);
+    if (isAbsent && (mod.state === "FAILED" || mod.state === "NOT_RUN")) {
+      problematic.push({ name, state: mod.state, hasPartialResults: false });
+    } else if (mod.state === "FAILED" && reportedProjects.has(name)) {
+      problematic.push({ name, state: mod.state, hasPartialResults: true });
     }
   }
-  return missing;
+  return problematic;
 }
 
 // merge reports that share the same projectName by concatenating testsuites


### PR DESCRIPTION
## Problem

`detectMissingModules` only flagged modules with **no** XML results. But a module whose `test` task times out **after** some test classes have already flushed their JUnit XML still appears in the report with green rows — its `FAILED` state in `build/test-metadata.json` was ignored, so the report said **success** for a build that actually timed out.

(Note: the companion kestra / kestra-ee PRs fix a second half of this — `test-metadata.json` wasn't even being written on timeout because `generateTestMetadata` was only a finalizer of `check`. This PR hardens the consumer side.)

## Fix

`detectProblematicModules` now surfaces both shapes:
- **absent** — test sources but no XML (state `FAILED`/`NOT_RUN`); module missing from the report (already handled)
- **partial** — module *is* in the report but its task state is `FAILED` (the timeout-after-partial-flush case; **new**)

Both set `hasErrors=true`, so `--fail-on-error` exits non-zero and the PR comment surfaces the timeout instead of a misleading green.

## Tests

Added coverage for partial-results, no-results, `NOT_RUN`, healthy-with-metadata, and the no-metadata backwards-compatible path. Verified end-to-end against a fixture with the real CLI: emits the ⚠️ warning, flips status to `failed ❌`, and exits 1.

`dist/` intentionally not rebuilt here — it is regenerated at release time via `npm version` (matching #35).

## Companion PRs
- kestra-io/kestra / kestra-io/kestra-ee — generate `test-metadata.json` even when a test task times out