### PR TITLE
fix(tests-reporting): use per-module timeout in test-metadata report

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: '22.12'
+          node-version: '22.x'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Upgrade npm

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: '22.12'
+          node-version: '22.x'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Upgrade npm

--- a/src/tests-reporting/functions/summarize-junit-report.test.ts
+++ b/src/tests-reporting/functions/summarize-junit-report.test.ts
@@ -364,7 +364,7 @@ describe("summarize-junit-report test", () => {
     expect(res.hasErrors).equal(true);
     expect(res.markdownContent).contain("java-module-1");
     expect(res.markdownContent).contain("partial");
-    expect(res.markdownContent).contain("30-minute");
+    expect(res.markdownContent).contain("timeout ≥ 30m");
   });
 
   it("should flag a FAILED module that produced no XML results at all (absent from the report)", async () => {
@@ -381,7 +381,27 @@ describe("summarize-junit-report test", () => {
     expect(res.hasErrors).equal(true);
     expect(res.markdownContent).contain("webserver-ee");
     expect(res.markdownContent).contain("not included");
-    expect(res.markdownContent).contain("30-minute");
+    expect(res.markdownContent).contain("timeout ≥ 30m");
+  });
+
+  it("should use a module's own timeoutMinutes instead of the top-level fallback", async () => {
+    // webserver-ee runs a longer suite than other modules and reports its own 45-minute
+    // timeout in metadata, distinct from the top-level (default) 30-minute value used by
+    // every other module. The report must reflect the module-specific value, not the global one.
+    const metadata: TestMetadata = {
+      timeoutMinutes: 30,
+      modules: {
+        "java-module-1": { state: "SUCCESS", hasTestSources: true, hasXmlResults: true },
+        "webserver-ee": { state: "FAILED", hasTestSources: true, hasXmlResults: false, timeoutMinutes: 45 },
+      },
+    };
+
+    const res = summarizeJunitReport(testReportsWithGreenTests, { onlyErrors: true, metadata });
+
+    expect(res.hasErrors).equal(true);
+    expect(res.markdownContent).contain("webserver-ee");
+    expect(res.markdownContent).contain("timeout ≥ 45m");
+    expect(res.markdownContent).not.contain("timeout ≥ 30m");
   });
 
   it("should flag a NOT_RUN module with test sources but no results", async () => {

--- a/src/tests-reporting/functions/summarize-junit-report.ts
+++ b/src/tests-reporting/functions/summarize-junit-report.ts
@@ -16,6 +16,9 @@ export interface TestMetadataModule {
   state: string;
   hasTestSources: boolean;
   hasXmlResults: boolean;
+  // Per-module test-task timeout (minutes), e.g. some modules run a longer suite than others.
+  // Falls back to the top-level TestMetadata.timeoutMinutes when absent (older producers).
+  timeoutMinutes?: number;
 }
 
 export interface TestMetadata {
@@ -43,13 +46,15 @@ export function summarizeJunitReport(
   const problematicModules = detectProblematicModules(metadata, testReports);
   if (problematicModules.length > 0) {
     hasErrors = true;
-    const timeoutMin = metadata?.timeoutMinutes ?? 30;
     const moduleLines = problematicModules.map((m) => {
+      // Per-module timeout when the producer reports one (e.g. webserver-ee runs longer than
+      // the default), falling back to the top-level value for older producers.
+      const timeoutMin = metadata?.modules?.[m.name]?.timeoutMinutes ?? metadata?.timeoutMinutes ?? 30;
       if (m.hasPartialResults) {
-        return `- \`${m.name}\` — test task **FAILED** (likely exceeded the ${timeoutMin}-minute timeout). The results shown below for this module are **partial** and may not reflect every test.`;
+        return `- \`${m.name}\` — test task **FAILED** and produced no complete results (JVM terminated — timeout ≥ ${timeoutMin}m, out-of-memory, or runner crash). The results shown below for this module are **partial** and may not reflect every test.`;
       }
       if (m.state === "FAILED") {
-        return `- \`${m.name}\` — test task **FAILED** (likely exceeded the ${timeoutMin}-minute timeout). Results for this module are **not included** in the report below.`;
+        return `- \`${m.name}\` — test task **FAILED** and produced no results (JVM terminated — timeout ≥ ${timeoutMin}m, out-of-memory, or runner crash). Results for this module are **not included** in the report below.`;
       }
       return `- \`${m.name}\` — test task state: ${m.state}. No test results were produced.`;
     });


### PR DESCRIPTION
## Summary
- `summarizeJunitReport` read a single top-level `timeoutMinutes` for every module, so a module with its own longer timeout (e.g. kestra-ee's `webserver-ee` at 45min vs the 30min default) was misreported as "likely exceeded the 30-minute timeout".
- Now reads `metadata.modules[name].timeoutMinutes` when present, falling back to the top-level value for older producers.
- Softened the wording: a missing/partial test report can be caused by an OOM or runner crash, not only a timeout — message now says "JVM terminated — timeout ≥ Nm, out-of-memory, or runner crash".

Companion producer-side change: kestra-io/kestra-ee#9433 (adds the per-module `timeoutMinutes` field to `test-metadata.json`).

## Test plan
- [x] `npx vitest run` — 43/43 passing (including 2 updated tests + 1 new test for per-module override)
- [x] `npx eslint .` — clean
- [x] `npx tsc -p tsconfig.types.json --noEmit` — compiles clean